### PR TITLE
Changed to show used command to execute tests

### DIFF
--- a/PythonTestOutput.hidden-tmLanguage
+++ b/PythonTestOutput.hidden-tmLanguage
@@ -8,6 +8,24 @@
 	<array>
 		<dict>
 			<key>begin</key>
+			<string>Command: </string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>test.command</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>command running</string>
+			<key>end</key>
+			<string>\n</string>
+			<key>match</key>
+			<string>"(.*)"</string>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>^[=-]+$</string>
 			<key>comment</key>
 			<string>error details</string>

--- a/PythonTestOutput.hidden-tmTheme
+++ b/PythonTestOutput.hidden-tmTheme
@@ -25,6 +25,17 @@
     </dict>
     <dict>
       <key>name</key>
+      <string>Command</string>
+      <key>scope</key>
+      <string>test.command</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#004ACA</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
       <string>Test</string>
       <key>scope</key>
       <string>test.pass</string>

--- a/plugin.py
+++ b/plugin.py
@@ -21,7 +21,7 @@ class RunPythonTestCommand(sublime_plugin.TextCommand):
         panel = self.view.window().create_output_panel('exec')
         panel.settings().set('color_scheme', self.color_scheme(settings))
 
-        command_print_msg = r'echo "Command: \"{}\""'.format(re.sub('"', '\\"', command))
+        command_print_msg = 'python -c "print(\'Command \\"{}\\"\')"'.format(re.sub('"', '\\"', command))
         command = command_print_msg + "; " + command
 
         self.view.window().run_command(

--- a/plugin.py
+++ b/plugin.py
@@ -20,6 +20,10 @@ class RunPythonTestCommand(sublime_plugin.TextCommand):
         # turn on language/theme for output panel somehow
         panel = self.view.window().create_output_panel('exec')
         panel.settings().set('color_scheme', self.color_scheme(settings))
+
+        command_print_msg = r'echo "Command: \"{}\""'.format(re.sub('"', '\\"', command))
+        command = command_print_msg + "; " + command
+
         self.view.window().run_command(
             "exec", {"cmd": [command],
                      "file_regex": TB_FILE,
@@ -57,21 +61,22 @@ class RunPythonTestCommand(sublime_plugin.TextCommand):
         matches = TEST_FUNC_RE.findall(tx)
         if not matches:
             return
-        print(matches)
+
         indent, funcname = matches[-1]
         if not indent:
             return funcname
+
         # find the enclosing class
         before = self.view.substr(sublime.Region(0, point))
-        print(len(before))
         classes = TEST_CASE_RE.findall(before)
-        print(classes)
+
         if not classes:
             return funcname  # this is probably bad
+
         candidates = [c for i, c in classes if len(i) < len(indent)]
-        print(candidates)
         if candidates:
             return "%s.%s" % (candidates[-1], funcname)
+
         return funcname  # also probably bad
 
     def file_to_module(self, wd, fn):


### PR DESCRIPTION
First line now will show the command used to run the tests.

With this changes, output will be something like this:

```
Command: "~/.virtualenvs/my-env/bin/python manage.py test my.package.myTestCase.test_something"
.
----------------------------------------------------------------------
Ran 1 test in 0.247s

OK
```

Please, take a look and tell me what do you think.

Thanks
